### PR TITLE
feat: minimize git server access by using meta data timestamps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Entry point at `src/main.rs` wires the clap CLI to subcommands; shared exports live in `src/lib.rs`.
+- CLI subcommands in `src/cli/` (`clone`, `mass`, `quick`, `profile`, `alias`, `update`) orchestrate workflows and regex filtering.
+- Provider clients in `src/git_api/` (GitHub/GitLab) and profile/config handling in `src/config/`; helper utilities (command runners, regex args) sit in `src/utils/`.
+- Packaging is defined by `Cargo.toml`; build outputs land in `target/`; transient logs (if any) stay in `build/logs/`.
+
+## Build, Test, and Development Commands
+- `cargo check` for quick validation; `cargo build --release` to produce the optimized binary.
+- `cargo run -- --help` to view usage; example: `cargo run -- clone org-name --regex ".*" --dry-run`.
+- `cargo fmt --all` enforces formatting; `cargo clippy --all-targets --all-features` catches lints (fix or allow with rationale).
+- `cargo test` runs the suite; use `cargo test -- --nocapture` when debugging print output.
+
+## Coding Style & Naming Conventions
+- Rust 2021 edition; keep `rustfmt.toml` defaults; run `cargo fmt` before commits.
+- Prefer clear error contexts; bubble errors with `Result` and avoid `expect`/`unwrap` outside tests or truly fatal conditions.
+- Modules and functions use `snake_case`; types `PascalCase`; constants `SCREAMING_SNAKE_CASE`.
+- Keep CLI prompts and user-visible strings concise; prefer `&str` over `String` when borrowing is enough.
+
+## Testing Guidelines
+- Add unit tests alongside modules with `#[cfg(test)]`; integration tests may live in `tests/` if cross-module.
+- For CLI flows, prefer testing command-building helpers instead of shelling out; stub network calls when possible.
+- Aim to cover new branches for provider handling (GitHub/GitLab) and regex filtering paths before merging.
+
+## Commit & Pull Request Guidelines
+- Follow conventional commit prefixes seen in history (`chore:`, `fix:`, `refactor:`, `style:`); keep messages imperative and under ~72 chars.
+- PRs should describe intent, note affected commands/flags, and list manual test steps (commands run with results).
+- Link related issues or TODOs; include output snippets or screenshots for user-facing changes.
+
+## Configuration & Security
+- User profiles live in `~/.config/grgry.toml`; never commit tokens or personal paths.
+- Use `--dry-run` flags when validating mass operations; avoid logging secrets returned from providers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +92,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -188,6 +203,20 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "cipher"
@@ -656,6 +685,7 @@ dependencies = [
 name = "grgry"
 version = "1.1.1"
 dependencies = [
+ "chrono",
  "clap",
  "colored",
  "config-file",
@@ -821,6 +851,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1134,6 +1188,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -2317,10 +2380,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ tar = "0.4"
 self-replace = "1.5.0"
 zip = "0.6"
 urlencoding = "2.1"
+chrono = { version = "0.4", features = ["serde"] }

--- a/src/cli/clone.rs
+++ b/src/cli/clone.rs
@@ -4,6 +4,7 @@ use crate::{
     utils::cmd::{create_git_cmd, run_cmd_o, run_cmd_o_soft, run_cmd_s_retry},
     utils::helper::{self, prntln, run_in_threads, MessageType},
 };
+use chrono::{DateTime, Utc};
 use regex::Regex;
 use reqwest::Client;
 use std::{
@@ -54,6 +55,7 @@ pub async fn clone(
         ),
         MessageType::Neutral,
     );
+    let branch_arg = branch.clone();
     // Limit concurrency for network-heavy git operations to reduce SSH connection resets.
     // (Fixes flaky failures like "kex_exchange_identification" when running many fetch/clone in parallel.)
     run_in_threads(
@@ -64,16 +66,79 @@ pub async fn clone(
                 format!("{}/{}", active_profile.targetbasepath, repo.full_path());
             let clone_url = get_clone_url(&active_profile.pulloption, repo);
             if Path::new(&destination_path).exists() {
-                // In dry-run mode, do not attempt to inspect or pull existing repos (would require
-                // executing git commands and can panic if output is missing/mocked).
                 if dry_run {
-                    prntln(
-                        &format!("Repo exists at {} (dry-run): would pull", destination_path),
-                        MessageType::Neutral,
-                    );
-                    ControlFlow::Continue(())
+                    let branch_from_metadata =
+                        determine_target_branch(&branch_arg, repo.default_branch());
+                    let target_branch =
+                        resolved_branch(&branch_arg, branch_from_metadata.as_deref(), &destination_path);
+
+                    let would_skip = branch_from_metadata
+                        .as_deref()
+                        .map(|b| should_skip_pull(b, repo, &destination_path))
+                        .unwrap_or(false);
+
+                    if would_skip {
+                        prntln(
+                            &format!(
+                                "Repo exists at {} (dry-run): remote not newer; would skip pull",
+                                destination_path
+                            ),
+                            MessageType::Success,
+                        );
+                        ControlFlow::Continue(())
+                    } else {
+                        match target_branch {
+                            Some(branch_name) => prntln(
+                                &format!(
+                                    "Repo exists at {} (dry-run): would pull branch {}",
+                                    destination_path, branch_name
+                                ),
+                                MessageType::Neutral,
+                            ),
+                            None => prntln(
+                                &format!(
+                                    "Repo exists at {} (dry-run): no cached origin refs; would skip pull",
+                                    destination_path
+                                ),
+                                MessageType::Success,
+                            ),
+                        }
+                        ControlFlow::Continue(())
+                    }
                 } else {
-                    pull(&branch, destination_path, clone_url, dry_run)
+                    let branch_from_metadata =
+                        determine_target_branch(&branch_arg, repo.default_branch());
+                    let target_branch =
+                        resolved_branch(&branch_arg, branch_from_metadata.as_deref(), &destination_path);
+
+                    if branch_from_metadata
+                        .as_deref()
+                        .map(|b| should_skip_pull(b, repo, &destination_path))
+                        .unwrap_or(false)
+                    {
+                        prntln(
+                            &format!(
+                                "Repository {} up-to-date locally (skipping pull)",
+                                clone_url
+                            ),
+                            MessageType::Success,
+                        );
+                        ControlFlow::Continue(())
+                    } else {
+                        match target_branch {
+                            Some(branch_name) => pull(&branch_name, destination_path, clone_url, dry_run),
+                            None => {
+                                prntln(
+                                    &format!(
+                                        "Repository {} has no cached origin refs; skipping pull to avoid network",
+                                        clone_url
+                                    ),
+                                    MessageType::Neutral,
+                                );
+                                ControlFlow::Continue(())
+                            }
+                        }
+                    }
                 }
             } else {
                 let mut cmd = Command::new("git");
@@ -117,12 +182,124 @@ pub async fn clone(
     prntln("\n\nFinished to clone repositories", MessageType::Success);
 }
 
-fn pull(
-    branch: &String,
-    destination_path: String,
-    clone_url: &str,
-    dry_run: bool,
-) -> ControlFlow<()> {
+fn determine_target_branch(cli_branch: &str, repo_default_branch: Option<&str>) -> Option<String> {
+    if !cli_branch.is_empty() {
+        // Only trust metadata when the requested branch matches the remote default.
+        if let Some(default_branch) = repo_default_branch {
+            if default_branch == cli_branch {
+                return Some(cli_branch.to_string());
+            }
+        }
+        return None;
+    }
+
+    repo_default_branch.map(|b| b.to_string())
+}
+
+fn resolved_branch(
+    cli_branch: &str,
+    metadata_branch: Option<&str>,
+    destination_path: &str,
+) -> Option<String> {
+    if let Some(b) = metadata_branch {
+        return Some(b.to_string());
+    }
+
+    if !cli_branch.is_empty() {
+        return Some(cli_branch.to_string());
+    }
+
+    if let Some(local_origin_branch) = best_local_origin_branch(destination_path) {
+        return Some(local_origin_branch);
+    }
+
+    None
+}
+
+fn should_skip_pull(branch: &str, repo: &Box<dyn Repo>, destination_path: &str) -> bool {
+    if let Some(remote_activity) = repo.last_activity_at() {
+        let (local_ts_str, ok) = run_cmd_o_soft(
+            create_git_cmd(destination_path)
+                .arg("log")
+                .arg("-1")
+                .arg("--format=%ct")
+                .arg(branch),
+            false,
+        );
+        if ok {
+            if let Some(local_ts) = parse_epoch_to_datetime(&local_ts_str) {
+                if remote_activity <= local_ts {
+                    return true;
+                }
+            }
+        }
+    }
+
+    // Fallback: compare local branch tip with cached remote-tracking ref without hitting the network.
+    let (local_sha, ok_local) = run_cmd_o_soft(
+        create_git_cmd(destination_path).arg("rev-parse").arg(branch),
+        false,
+    );
+    let (remote_sha, ok_remote) = run_cmd_o_soft(
+        create_git_cmd(destination_path)
+            .arg("rev-parse")
+            .arg(format!("origin/{}", branch)),
+        false,
+    );
+
+    if ok_remote && !remote_sha.is_empty() {
+        return ok_local && !local_sha.is_empty() && local_sha == remote_sha;
+    }
+
+    // If we have no cached remote ref, avoid server load by skipping.
+    true
+}
+
+fn parse_epoch_to_datetime(epoch: &str) -> Option<DateTime<Utc>> {
+    let seconds: i64 = epoch.trim().parse().ok()?;
+    DateTime::from_timestamp(seconds, 0)
+}
+
+fn best_local_origin_branch(destination_path: &str) -> Option<String> {
+    // First, try origin/HEAD if it exists locally.
+    let (symbolic_ref, ok) = run_cmd_o_soft(
+        create_git_cmd(destination_path)
+            .arg("symbolic-ref")
+            .arg("refs/remotes/origin/HEAD")
+            .arg("--short"),
+        false,
+    );
+    if ok {
+        if let Some(branch_name) = symbolic_ref.strip_prefix("origin/") {
+            if !branch_name.is_empty() {
+                return Some(branch_name.to_string());
+            }
+        }
+    }
+
+    // Next, pick the most recently updated remote branch from local refs.
+    let (branches, ok_branches) = run_cmd_o_soft(
+        create_git_cmd(destination_path)
+            .arg("for-each-ref")
+            .arg("--format=%(refname:short)")
+            .arg("--sort=-committerdate")
+            .arg("refs/remotes/origin"),
+        false,
+    );
+    if ok_branches {
+        if let Some(first) = branches.lines().find(|l| l.starts_with("origin/")) {
+            if let Some(name) = first.strip_prefix("origin/") {
+                if !name.is_empty() {
+                    return Some(name.to_string());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn pull(branch: &str, destination_path: String, clone_url: &str, dry_run: bool) -> ControlFlow<()> {
     let current_branch = match get_current_pull_branch(branch, &destination_path, dry_run) {
         Ok(value) => value,
         Err(value) => return value,

--- a/src/git_api/git_providers.rs
+++ b/src/git_api/git_providers.rs
@@ -32,6 +32,8 @@ pub trait Repo: Send + Sync {
     fn ssh_url(&self) -> &str;
     fn http_url(&self) -> &str;
     fn full_path(&self) -> &str;
+    fn default_branch(&self) -> Option<&str>;
+    fn last_activity_at(&self) -> Option<chrono::DateTime<chrono::Utc>>;
 }
 
 pub async fn get_repos_paralell(

--- a/src/git_api/github.rs
+++ b/src/git_api/github.rs
@@ -9,6 +9,7 @@ use crate::{
     config::config::Profile,
     git_api::git_providers::{call_api, get_repos_paralell, GitProvider, Repo},
 };
+use chrono::{DateTime, Utc};
 const PER_PAGE: i16 = 100;
 
 #[derive(Debug, Deserialize)]
@@ -16,6 +17,8 @@ pub struct GithubRepo {
     pub ssh_url: String,
     pub clone_url: String,
     pub full_name: String,
+    pub default_branch: Option<String>,
+    pub pushed_at: Option<DateTime<Utc>>,
 }
 
 impl Repo for GithubRepo {
@@ -29,6 +32,14 @@ impl Repo for GithubRepo {
 
     fn full_path(&self) -> &str {
         &self.full_name
+    }
+
+    fn default_branch(&self) -> Option<&str> {
+        self.default_branch.as_deref()
+    }
+
+    fn last_activity_at(&self) -> Option<DateTime<Utc>> {
+        self.pushed_at
     }
 }
 

--- a/src/git_api/gitlab.rs
+++ b/src/git_api/gitlab.rs
@@ -5,6 +5,7 @@ use crate::{
     git_api::git_providers::{call_api, get_repos_paralell, GitProvider, Repo},
 };
 
+use chrono::{DateTime, Utc};
 use colored::Colorize;
 use reqwest::{Client, Response};
 use serde::Deserialize;
@@ -17,6 +18,9 @@ pub(crate) struct GitlabRepo {
     pub ssh_url_to_repo: String,
     pub http_url_to_repo: String,
     pub path_with_namespace: String,
+    pub default_branch: Option<String>,
+    pub last_activity_at: Option<DateTime<Utc>>,
+    pub last_repository_activity_at: Option<DateTime<Utc>>,
 }
 
 impl Repo for GitlabRepo {
@@ -30,6 +34,15 @@ impl Repo for GitlabRepo {
 
     fn full_path(&self) -> &str {
         &self.path_with_namespace
+    }
+
+    fn default_branch(&self) -> Option<&str> {
+        self.default_branch.as_deref()
+    }
+
+    fn last_activity_at(&self) -> Option<DateTime<Utc>> {
+        self.last_repository_activity_at
+            .or(self.last_activity_at)
     }
 }
 


### PR DESCRIPTION
Implemented smarter pull avoidance: 
- Provider repos now carry default branch and last-activity metadata, clone uses that plus cached origin refs (timestamps and SHA comparisons) to skip pulls when remote isn’t newer, and handles missing default branches/refs by avoiding network and updating dry-run messaging. 
- Added chrono dependency to support timestamp parsing. 
- Also added AGENTS.md contributor guidelines to outline structure, commands, style, and PR expectations.